### PR TITLE
Update Composer's SHA hash as needed

### DIFF
--- a/bin/setup.sh
+++ b/bin/setup.sh
@@ -6,7 +6,7 @@ then
 else
 	echo "WordPress config file not found. Installing..."
     php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
-    php -r "if (hash_file('SHA384', 'composer-setup.php') === '55d6ead61b29c7bdee5cccfb50076874187bd9f21f65d8991d46ec5cc90518f447387fb9f76ebae1fbbacf329e583e30') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
+    php -r "if (hash_file('SHA384', 'composer-setup.php') === '544e09ee996cdf60ece3804abc52599c22b1f40f4323403c44d44fdfdd586475ca9813a858088ffbc1f233e9b180f061') { echo 'Installer verified'; } else { echo 'Installer corrupt'; unlink('composer-setup.php'); } echo PHP_EOL;"
     php composer-setup.php --install-dir=bin
     php -r "unlink('composer-setup.php');"
     php ./bin/composer.phar --working-dir=site/ install


### PR DESCRIPTION
I was getting an `Installer corrupt` error on account of the outdated SHA384 hash. This PR only updates it.